### PR TITLE
adjusted my portfolio and github links to be on seprate lines

### DIFF
--- a/src/robots.js
+++ b/src/robots.js
@@ -1839,7 +1839,7 @@ export const robots = [
         name: "Thomas Dreyer",
 
         deprecated_website: <div><a href="https://www.fsdev.ml" target="_blank" rel="noopener noreferrer">Portfolio
-            Site</a>
+            Site</a><br/><br/>
             <a href="https://github.com/thomasdreyer" target="_blank" rel="noopener noreferrer">Github</a>
     <br></br>
             <a href="https://www.linkedin.com/in/thomas-dreyer" target="_blank" rel="noopener noreferrer">Linkedin</a>


### PR DESCRIPTION
Hi, thanks for the previous merge, I had a look at my info on the site and my portfolio link and github link were both on the same line which makes it a bit difficult for a user to click on it, I adjusted them to be on seprate lines, please have a look and merge if it is all in order.

Thank you for your help.