### PR TITLE
Fix personal website link

### DIFF
--- a/src/persons.js
+++ b/src/persons.js
@@ -1159,7 +1159,7 @@ export const persons = [
         name: "Zachary Fons",
         img: "https://i.imgur.com/a0tBLzl.jpg",
         links: {
-            website: "zacharyfons.me",
+            website: "http://zacharyfons.me",
             linkedin: "https://www.linkedin.com/in/zacharyfons/",
             github: "https://www.github.com/nofcaz/"
         },


### PR DESCRIPTION
Without http://, link goes to job board instead of personal site.