### PR TITLE
Fixed my github URL info

### DIFF
--- a/src/assets/persons.json
+++ b/src/assets/persons.json
@@ -7492,7 +7492,7 @@
       "links": {
         "website": "",
         "linkedin": "https://www.linkedin.com/in/milton-omena/",
-        "github": "https://https://github.com/omenaneto"
+        "github": "https://github.com/omenaneto"
       },
       "jobTitle": "Full Stack Dev.",
       "location": {


### PR DESCRIPTION
Hi, I uploaded my info to the job board this afternoon but only now saw that my GitHub link wasn't leading to my page. Minor oversight