### PR TITLE
Normalizing IDs even if ID was wrong in json

### DIFF
--- a/src/util/UsersDataCleanup.tsx
+++ b/src/util/UsersDataCleanup.tsx
@@ -1,12 +1,19 @@
+import data from "../assets/persons.json"
 /* CLEAN UP THE persons.json DATA TO MAKE IT EASIER 
 TO MAKE FETCH REQUESTS FOR COUNTRIES AND COORDINATES 
 (LATITUDE, LONGITUDE) AND COMPARE AND MATCH THEM */
 
 import Person from "../interfaces/person"
-import data from "../assets/persons.json"
 
 const people: any = data.people
 
+const normalizeIDs = () => {
+  people.forEach((person: Person, index: number) => {
+    person.id = index + 1
+  })
+}
+
+normalizeIDs()
 // Removed all the brackets, extra spaces, symbols and unnecessary stuff from country names
 const allCountryNamesCleaned = people.map((person: Person) => {
   return (


### PR DESCRIPTION
I added a function in the UsersDataCleanup.tsx file that will re-organize the IDs to be index+1 since there were some users who had accidentally put the wrong ID in the JSON file. I had no idea where to put this function, but from the name of the file it sounded like a good place. 

I appreciate any comments :)