### PR TITLE
fix-github-redirects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,7 @@ function App() {
         <a
           href="https://github.com/zero-to-mastery/ZtM-Job-Board"
           title="Repository"
+          target="_blank"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
fixes issue #2923

external links should be opened in a new tab, so I fixed this by adding `target="_blank"`