### PR TITLE
Fix dependency errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "@types/react": "^18.2.20",
                 "@types/react-dom": "^18.2.7",
                 "@types/react-lazyload": "^3.1.1",
-                "@types/react-leaflet": "^3.0.0",
                 "@types/webfontloader": "^1.6.34",
                 "g": "^2.0.1",
                 "leaflet": "^1.7.1",
@@ -28,12 +27,14 @@
                 "react-search-input": "^0.11.3",
                 "sass": "^1.49.8",
                 "tachyons": "^4.12.0",
-                "typescript": "^5.1.6",
+                "typescript": "^4.9.5",
                 "uuid": "^8.3.2",
                 "webfontloader": "^1.6.28"
             },
             "devDependencies": {
                 "@babel/helper-call-delegate": "^7.12.13",
+                "@types/leaflet": "^1.9.5",
+                "@types/react-leaflet": "^3.0.0",
                 "gh-pages": "^3.2.3",
                 "glob-all": "^3.2.1",
                 "husky": "^7.0.4",
@@ -3580,6 +3581,12 @@
                 "@types/range-parser": "*"
             }
         },
+        "node_modules/@types/geojson": {
+            "version": "7946.0.11",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
+            "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==",
+            "dev": true
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3901,6 +3908,15 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
         },
+        "node_modules/@types/leaflet": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.5.tgz",
+            "integrity": "sha512-C+aD2/DueS+cVltMBPUHQPhgM99E3eXG4kw8/USIUxUxdqTiIGnifdDpnD/491CGsMzQ4bMvGtxUJBArFnhQSw==",
+            "dev": true,
+            "dependencies": {
+                "@types/geojson": "*"
+            }
+        },
         "node_modules/@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -3972,6 +3988,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-leaflet/-/react-leaflet-3.0.0.tgz",
             "integrity": "sha512-p8R9mVKbCDDqOdW+M6GyJJuFn6q+IgDFYavFiOIvaWHuOe5kIHZEtCy1pfM43JIA6JiB3D/aDoby7C51eO+XSg==",
             "deprecated": "This is a stub types definition. react-leaflet provides its own type definitions, so you do not need this installed.",
+            "dev": true,
             "dependencies": {
                 "react-leaflet": "*"
             }
@@ -18969,15 +18986,15 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=4.2.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -22500,7 +22517,8 @@
         "@react-leaflet/core": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
-            "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg=="
+            "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+            "requires": {}
         },
         "@rollup/plugin-babel": {
             "version": "5.3.0",
@@ -22834,6 +22852,12 @@
                 "@types/range-parser": "*"
             }
         },
+        "@types/geojson": {
+            "version": "7946.0.11",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
+            "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==",
+            "dev": true
+        },
         "@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -23090,6 +23114,15 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
         },
+        "@types/leaflet": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.5.tgz",
+            "integrity": "sha512-C+aD2/DueS+cVltMBPUHQPhgM99E3eXG4kw8/USIUxUxdqTiIGnifdDpnD/491CGsMzQ4bMvGtxUJBArFnhQSw==",
+            "dev": true,
+            "requires": {
+                "@types/geojson": "*"
+            }
+        },
         "@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -23160,6 +23193,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/react-leaflet/-/react-leaflet-3.0.0.tgz",
             "integrity": "sha512-p8R9mVKbCDDqOdW+M6GyJJuFn6q+IgDFYavFiOIvaWHuOe5kIHZEtCy1pfM43JIA6JiB3D/aDoby7C51eO+XSg==",
+            "dev": true,
             "requires": {
                 "react-leaflet": "*"
             }
@@ -23627,12 +23661,14 @@
         "acorn-import-assertions": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "requires": {}
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "requires": {}
         },
         "acorn-node": {
             "version": "1.8.2",
@@ -23742,7 +23778,8 @@
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "requires": {}
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -24108,7 +24145,8 @@
         "babel-plugin-named-asset-import": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
+            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+            "requires": {}
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.3.1",
@@ -25056,7 +25094,8 @@
         "css-prefers-color-scheme": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
+            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+            "requires": {}
         },
         "css-select": {
             "version": "4.2.1",
@@ -25155,7 +25194,8 @@
         "cssnano-utils": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.0.2.tgz",
-            "integrity": "sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ=="
+            "integrity": "sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ==",
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -26111,7 +26151,8 @@
         "eslint-plugin-react-hooks": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-            "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
+            "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+            "requires": {}
         },
         "eslint-plugin-testing-library": {
             "version": "5.0.5",
@@ -27637,7 +27678,8 @@
         "icss-utils": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "requires": {}
         },
         "idb": {
             "version": "6.1.5",
@@ -28888,7 +28930,8 @@
         "jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -31014,7 +31057,8 @@
         "postcss-browser-comments": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
+            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
+            "requires": {}
         },
         "postcss-calc": {
             "version": "8.2.4",
@@ -31079,7 +31123,8 @@
         "postcss-custom-media": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-            "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g=="
+            "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+            "requires": {}
         },
         "postcss-custom-properties": {
             "version": "12.1.4",
@@ -31108,22 +31153,26 @@
         "postcss-discard-comments": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz",
-            "integrity": "sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q=="
+            "integrity": "sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q==",
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz",
-            "integrity": "sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw=="
+            "integrity": "sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw==",
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz",
-            "integrity": "sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA=="
+            "integrity": "sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA==",
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz",
-            "integrity": "sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg=="
+            "integrity": "sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==",
+            "requires": {}
         },
         "postcss-double-position-gradients": {
             "version": "3.1.0",
@@ -31145,7 +31194,8 @@
         "postcss-flexbugs-fixes": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
+            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
+            "requires": {}
         },
         "postcss-focus-visible": {
             "version": "6.0.4",
@@ -31166,12 +31216,14 @@
         "postcss-font-variant": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+            "requires": {}
         },
         "postcss-gap-properties": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
-            "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ=="
+            "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
+            "requires": {}
         },
         "postcss-image-set-function": {
             "version": "4.0.6",
@@ -31184,7 +31236,8 @@
         "postcss-initial": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
+            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+            "requires": {}
         },
         "postcss-js": {
             "version": "4.0.0",
@@ -31235,12 +31288,14 @@
         "postcss-logical": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
+            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+            "requires": {}
         },
         "postcss-media-minmax": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+            "requires": {}
         },
         "postcss-merge-longhand": {
             "version": "5.0.6",
@@ -31301,7 +31356,8 @@
         "postcss-modules-extract-imports": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -31358,7 +31414,8 @@
         "postcss-normalize-charset": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz",
-            "integrity": "sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA=="
+            "integrity": "sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA==",
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.0.3",
@@ -31443,12 +31500,14 @@
         "postcss-overflow-shorthand": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
-            "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg=="
+            "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
+            "requires": {}
         },
         "postcss-page-break": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+            "requires": {}
         },
         "postcss-place": {
             "version": "7.0.4",
@@ -31535,7 +31594,8 @@
         "postcss-replace-overflow-wrap": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+            "requires": {}
         },
         "postcss-selector-not": {
             "version": "5.0.0",
@@ -32014,7 +32074,8 @@
         },
         "react-lazyload": {
             "version": "git+ssh://git@github.com/twobin/react-lazyload.git#f1faffda816180f39d3ff8cf3d9c2060f8d9d623",
-            "from": "react-lazyload@github:twobin/react-lazyload"
+            "from": "react-lazyload@github:twobin/react-lazyload",
+            "requires": {}
         },
         "react-leaflet": {
             "version": "4.2.1",
@@ -33356,7 +33417,8 @@
         "style-loader": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+            "requires": {}
         },
         "stylehacks": {
             "version": "5.0.3",
@@ -33931,9 +33993,9 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
         },
         "unbox-primitive": {
             "version": "1.0.1",
@@ -34481,7 +34543,8 @@
                 "ws": {
                     "version": "8.5.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-                    "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
+                    "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+                    "requires": {}
                 }
             }
         },
@@ -34952,7 +35015,8 @@
         "ws": {
             "version": "7.5.7",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-            "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+            "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+            "requires": {}
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@types/react-lazyload": "^3.1.1",
-        "@types/react-leaflet": "^3.0.0",
         "@types/webfontloader": "^1.6.34",
         "g": "^2.0.1",
         "leaflet": "^1.7.1",
@@ -25,7 +24,7 @@
         "react-search-input": "^0.11.3",
         "sass": "^1.49.8",
         "tachyons": "^4.12.0",
-        "typescript": "^5.1.6",
+        "typescript": "^4.9.5",
         "uuid": "^8.3.2",
         "webfontloader": "^1.6.28"
     },
@@ -53,6 +52,8 @@
     },
     "devDependencies": {
         "@babel/helper-call-delegate": "^7.12.13",
+        "@types/leaflet": "^1.9.5",
+        "@types/react-leaflet": "^3.0.0",
         "gh-pages": "^3.2.3",
         "glob-all": "^3.2.1",
         "husky": "^7.0.4",
@@ -63,7 +64,12 @@
         "prettier": "^2.5.1",
         "purgecss-webpack-plugin": "^4.1.3"
     },
-    "browserslist": [">0.2%", "not dead", "not ie <= 11", "not op_mini all"],
+    "browserslist": [
+        ">0.2%",
+        "not dead",
+        "not ie <= 11",
+        "not op_mini all"
+    ],
     "volta": {
         "node": "18.17.1"
     }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -106,7 +106,6 @@ function SimpleMap({ zoom = 3 }) {
                 doubleClickZoom={true}
                 scrollWheelZoom={true}
                 dragging={true}
-                animate={true}
                 easeLinearity={0.35}
             >
                 <TileLayer


### PR DESCRIPTION
We need an older TypeScript version (max. v4)
and updated types to make this work.

The `animate` attribute does not exist anymore
on the Leaflet Map, so I removed it.