### PR TITLE
Add Filimon Kifle Profile to Submissions Folder

### DIFF
--- a/Submissions/filimonkd.json
+++ b/Submissions/filimonkd.json
@@ -1,0 +1,16 @@
+{
+    "name": "FIlimon Kifle",
+    "img": "https://avatars.githubusercontent.com/u/40231410?v=4",
+    "email": "filimonkd@gmail.com",
+    "links": {
+      "website": "https://filimonportfolio.netlify.app/",
+      "linkedin": "https://www.linkedin.com/in/filimonkd",
+      "github": "https://github.com/filimonkd"
+    },
+    "jobTitle": "Full Stack Developer",
+    "location": {
+      "city": "Addis Ababa",
+      "state": "",
+      "country": "Ethiopia"
+    }
+  }


### PR DESCRIPTION
This pull request adds my profile to the Submissions folder in a JSON format. The profile includes my personal information, social media links, and professional details.

- **Name**: Filimon Kifle
- **Profile Image**: [GitHub Avatar](https://avatars.githubusercontent.com/u/40231410?v=4)
- **Email**: filimonkd@gmail.com
- **Links**:
  - [Website](https://filimonportfolio.netlify.app/)
  - [LinkedIn](https://www.linkedin.com/in/filimonkd)
  - [GitHub](https://github.com/filimonkd)
- **Job Title**: Full Stack Developer
- **Location**: Addis Ababa, Ethiopia

Thank you for considering my contribution!
