### PR TITLE
fix: header overlap with other content in smaller screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App() {
 
     return (
         <div className="flex flex-column min-vh-100 tc">
-            <header className="custom--unselectable fixed top-0 w-100 white custom--bg-additional3 custom--shadow-4 z-9999">
+            <header className="custom--unselectable top-0 w-100 white custom--bg-additional3 custom--shadow-4 z-9999">
                 <Navbar
                     onLogoClick={goBack}
                     onSearchChange={(e: any) => setSearchfield(e.target.value)}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,9 +80,6 @@ const Navbar = ({
                     Text={isDarkMode ? 'Light Mode' : 'Dark Mode'}
                     TooltipText={`Click to enable ${isDarkMode ? 'light' : 'dark'} mode`}
                 />
-                {/*<button onClick={handleDarkModeToggle} className="pointer">
-                    {isDarkMode ? 'Light Mode' : 'Dark Mode'}
-                </button>*/}
             </div>
         </div>
     )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -41,7 +41,7 @@ const Navbar = ({
             <h1
                 onClick={onLogoClick}
                 id="title"
-                className="relative ma0 pa0 fl-l pointer"
+                className="relative ma0 mr4 pa0 fl-l pointer"
             >
                 <svg className="w2 h2 mr2 v-top" viewBox="0 0 24 24">
                     <path d="M12,6A3,3 0 0,0 9,9A3,3 0 0,0 12,12A3,3 0 0,0 15,9A3,3 0 0,0 12,6M6,8.17A2.5,2.5 0 0,0 3.5,10.67A2.5,2.5 0 0,0 6,13.17C6.88,13.17 7.65,12.71 8.09,12.03C7.42,11.18 7,10.15 7,9C7,8.8 7,8.6 7.04,8.4C6.72,8.25 6.37,8.17 6,8.17M18,8.17C17.63,8.17 17.28,8.25 16.96,8.4C17,8.6 17,8.8 17,9C17,10.15 16.58,11.18 15.91,12.03C16.35,12.71 17.12,13.17 18,13.17A2.5,2.5 0 0,0 20.5,10.67A2.5,2.5 0 0,0 18,8.17M12,14C10,14 6,15 6,17V19H18V17C18,15 14,14 12,14M4.67,14.97C3,15.26 1,16.04 1,17.33V19H4V17C4,16.22 4.29,15.53 4.67,14.97M19.33,14.97C19.71,15.53 20,16.22 20,17V19H23V17.33C23,16.04 21,15.26 19.33,14.97Z" />
@@ -75,9 +75,14 @@ const Navbar = ({
                     </div>
                 )}
                 {/* Dark mode toggle button */}
-                <button onClick={handleDarkModeToggle} className="ml3 pointer">
+                <Pointer
+                    onClick={handleDarkModeToggle}
+                    Text={isDarkMode ? 'Light Mode' : 'Dark Mode'}
+                    TooltipText={`Click to enable ${isDarkMode ? 'light' : 'dark'} mode`}
+                />
+                {/*<button onClick={handleDarkModeToggle} className="pointer">
                     {isDarkMode ? 'Light Mode' : 'Dark Mode'}
-                </button>
+                </button>*/}
             </div>
         </div>
     )

--- a/src/index.scss
+++ b/src/index.scss
@@ -46,7 +46,8 @@ $colors: (
     $b3,
     $s3
 ) {
-    box-shadow: #{$h1}px #{$v1}px #{$b1}px #{$s1}px rgba(0, 0, 0, 0.2),
+    box-shadow:
+        #{$h1}px #{$v1}px #{$b1}px #{$s1}px rgba(0, 0, 0, 0.2),
         #{$h2}px #{$v2}px #{$b2}px #{$s2}px rgba(0, 0, 0, 0.14),
         #{$h3}px #{$v3}px #{$b3}px #{$s3}px rgba(0, 0, 0, 0.12);
 }
@@ -58,7 +59,8 @@ $colors: (
 }
 
 * {
-    transition: color 280ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+    transition:
+        color 280ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
         background-color 280ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
         border-color 280ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
         box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -85,7 +87,7 @@ input {
 }
 
 header {
-    padding: 0 5%;
+    position: sticky;
 
     .header-items {
         transition: height 0.3s ease;
@@ -281,7 +283,7 @@ header {
 }
 
 main {
-    margin: 7rem 5% 1rem 5%;
+    margin: 1rem 5%;
 
     .card {
         min-height: 26rem;


### PR DESCRIPTION
Issue:
- Header is overlapping with the below content for smaller screens.

Changes:
- Header is changed from ```position:fixed``` to ```position:sticky```. This allows header to have position as ```fixed``` when scrolling and ```relative``` when it isn't.
- Added right margin to logo as the logo and navigation buttons are too close for certain screen widths.
- Refactored the code of dark mode toggle button to use the existing code design language.
- Adjusted spacing for ```header``` and ```main``` elements.