### PR TITLE
Add basic PWA support (manifest + service worker)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "ZtM Job Board",
+  "short_name": "JobBoard",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4c4c4c",
+  "icons": [
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,47 @@
+const CACHE_NAME = 'ztm-job-board-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  // Add paths to main.js, main.css, and key assets/images here
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request)
+      .then(response => response || fetch(event.request))
+  );
+});
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+
+  // cache map JS chunk (same-origin)
+  if (url.origin === location.origin && url.pathname.includes('Map') && url.pathname.endsWith('.js')) {
+    event.respondWith(
+      caches.match(req).then(cached => cached || fetch(req).then(res => {
+        const copy = res.clone();
+        caches.open('jb-v1').then(c => c.put(req, copy));
+        return res;
+      }))
+    );
+    return;
+  }
+
+  // cache 3rd-party tiles (update in the background)
+  if (/tile|tiles|maps/i.test(url.hostname)) {
+    event.respondWith(staleWhileRevalidate(req));
+    return;
+  }
+
+  // ...your other routes
+});


### PR DESCRIPTION
[index.html](https://github.com/user-attachments/files/23305025/index.html)

Added manifest.json for PWA metadata
Added service-worker.js for offline caching
Updated index.html to register service worker and link manifest
Tested installability and offline mode locally
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/ef5d60ce-b66e-4c8d-8d46-1a18fae5f44c" />
<img width="1919" height="916" alt="Screenshot 2025-11-03 203604" src="https://github.com/user-attachments/assets/ba5d8df1-7933-47e2-8190-7fa93d88423a" />

