### PR TITLE
feat: add skeleton loader for map component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import persons from './assets/persons.json'
 import { pageNames } from './util/pageNames'
 import useForceUpdate from './util/useForceUpdate'
 const SimpleMap = lazy(() => import('./components/Map'))
+import SimpleMapSkeleton from './components/MapSkeleton'
 
 const people: any = persons
 
@@ -72,17 +73,7 @@ function App() {
             </header>
             <main className="flex-auto">
                 {map ? (
-                    <Suspense
-                        fallback={
-                            <div>
-                                <p>Loading Map...</p>
-                                <p>
-                                    Try refreshing if it doesn't load or check
-                                    internet connection and try again later.
-                                </p>
-                            </div>
-                        }
-                    >
+                    <Suspense fallback={<SimpleMapSkeleton />}>
                         <SimpleMap />
                     </Suspense>
                 ) : (

--- a/src/components/MapSkeleton.tsx
+++ b/src/components/MapSkeleton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import '../styles/MapSkeleton.scss'
+
+function MapSkeleton() {
+    return (
+        <div className="map-skeleton" aria-label="Loading map">
+            <div className="map-skeleton__grid">
+                <div className="map-skeleton__tile" />
+                <div className="map-skeleton__tile" />
+                <div className="map-skeleton__tile" />
+                <div className="map-skeleton__tile" />
+                <div className="map-skeleton__tile" />
+                <div className="map-skeleton__tile" />
+            </div>
+            <div className="map-skeleton__marker" />
+            <div className="map-skeleton__attribution" />
+        </div>
+    )
+}
+
+export default MapSkeleton

--- a/src/styles/MapSkeleton.scss
+++ b/src/styles/MapSkeleton.scss
@@ -1,0 +1,73 @@
+@keyframes map-skeleton__shimmer {
+    0% {
+        background-position: -200% 0;
+    }
+    100% {
+        background-position: 200% 0;
+    }
+}
+
+.map-skeleton {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    height: 90vh;
+    width: 100%;
+    margin: 0;
+    background-color: #f5f5f5;
+    border-radius: 4px;
+    overflow: hidden;
+
+    &__grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+        width: 80%;
+        max-width: 600px;
+    }
+
+    &__tile {
+        aspect-ratio: 1;
+        border-radius: 4px;
+        background: linear-gradient(
+            90deg,
+            #f5f5f5 25%,
+            #9e9e9e 50%,
+            #f5f5f5 75%
+        );
+        background-size: 200% 100%;
+        animation: map-skeleton__shimmer 1.5s ease-in-out infinite;
+    }
+
+    &__marker {
+        width: 3rem;
+        height: 3rem;
+        border-radius: 50%;
+        background: linear-gradient(
+            90deg,
+            #f5f5f5 25%,
+            #2196f3 50%,
+            #f5f5f5 75%
+        );
+        background-size: 200% 100%;
+        animation: map-skeleton__shimmer 1.5s ease-in-out infinite;
+        opacity: 0.6;
+    }
+
+    &__attribution {
+        width: 60%;
+        max-width: 400px;
+        height: 1rem;
+        border-radius: 4px;
+        background: linear-gradient(
+            90deg,
+            #f5f5f5 25%,
+            #9e9e9e 50%,
+            #f5f5f5 75%
+        );
+        background-size: 200% 100%;
+        animation: map-skeleton__shimmer 1.5s ease-in-out infinite;
+    }
+}


### PR DESCRIPTION
Closes #3433

Replaced the plain text Suspense fallback with a CSS-animated skeleton
loader that matches the map layout (tile grid + marker + attribution bar).