### PR TITLE
feat: use article element for cards and fix button contrast

### DIFF
--- a/src/components/BasicButton.tsx
+++ b/src/components/BasicButton.tsx
@@ -15,6 +15,7 @@ const BasicButton = ({ action, children, disabled }: BasicButtonProps) => {
                 className={`f5 no-underline black bg-animate hover-bg-black hover-white inline-flex items-center pa3 ba border-box b--dark-gray br2 ${disabled ? 'disabled' : ''}`}
                 onClick={action}
                 disabled={disabled}
+                style={{ '--btn-bg': '#f5f5f5' } as React.CSSProperties}
             >
                 {children}
             </button>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -13,9 +13,10 @@ const Card = ({ user }: any) => {
 
     if (id) {
         return (
-            <div
+            <article
                 id={`person-${id}`}
                 className="card ma3 w5 tc bg-white br3 custom--shadow-2 custom--shadow-hover-8 custom--o-95 z-1"
+                aria-labelledby={`name-${id}`}
             >
                 <div className="header relative pt3 br2 br--top z-0">
                     <img
@@ -28,7 +29,7 @@ const Card = ({ user }: any) => {
                         decoding="async"
                         onError={(e) => addDefaultImg(e)}
                     />
-                    <h2 className="name mt3 mb1 ph3 w-100 flex items-center justify-center">
+                    <h2 id={`name-${id}`} className="name mt3 mb1 ph3 w-100 flex items-center justify-center">
                         {name}
                     </h2>
                     <p className="title text-center">{jobTitle}</p>
@@ -103,10 +104,10 @@ const Card = ({ user }: any) => {
                             .join(', ')}
                     </p>
                 </div>
-            </div>
+            </article>
         )
     } else {
-        return <div></div>
+        return null
     }
 }
 

--- a/src/styles/BasicButton.scss
+++ b/src/styles/BasicButton.scss
@@ -8,7 +8,7 @@
 }
 
 .custom--basic-button button {
-    background: transparent;
+    background: var(--btn-bg, transparent);
     &:hover {
         cursor: pointer;
     }


### PR DESCRIPTION
Closes #3524 

Changed card root element from div to article with aria-labelledby for proper semantic HTML.
Added visible background (#f5f5f5) to BasicButton via CSS variable for contrast accessibility.
Returned null instead of empty div in Card.tsx (carried over from previous fix).